### PR TITLE
Tests running with tracked MiniMeToken

### DIFF
--- a/contracts/campaigns/VegaCampaign.sol
+++ b/contracts/campaigns/VegaCampaign.sol
@@ -17,7 +17,7 @@ pragma solidity ^0.4.15;
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/// @author Jordi Baylina, Arthur Lunn
+/// @author Arthur Lunn (Adapted from code from Jordi Baylina)
 /// @dev This contract controls the issuance of tokens for the VegaToken Contract.
 /// Going forward this contract needs to be modified to adhear to the VegaToken campaign parameters. 
 
@@ -29,7 +29,6 @@ import "../helpers/Owned.sol";
 /// @dev This is designed to control the issuance of a MiniMe Token for a
 ///  non-profit Campaign. This contract effectively dictates the terms of the
 ///  funding round. This campaign is designed to be no-limit; there is no maximum funding.
-
 contract VegaCampaign is TokenController, Owned {
 
     uint public startFundingTime;       // In UNIX Time Format

--- a/contracts/proposals/financial/Financial.sol
+++ b/contracts/proposals/financial/Financial.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.15;
 import "../Common.sol";
 
 import "../../../node_modules/zeppelin-solidity/contracts/token/ERC20Basic.sol";
-
+import {Vault} from "../../../node_modules/vaultcontract/contracts/Vault.sol";
 
 /**@title Allocation Proposal
 * Allocation proposals send tokens held by Vega to another contract or address. This contract could be a token sale,
@@ -17,7 +17,7 @@ contract Financial is Common {
       uint256 public amount;
       // Vote is stored in this token so that contracts with knowledge of this proposal can check it's vote state.
       address public vote;
-
+      uint idPayment;
   	/**
   	* @dev Main constructor for a Common proposal
   	*/
@@ -38,4 +38,8 @@ contract Financial is Common {
     }
 
     function execute(address _vga) public;
+
+    function setPaymentId(uint _idPayment){
+      idPayment = _idPayment;
+    }
 }

--- a/contracts/tokens/VegaToken.sol
+++ b/contracts/tokens/VegaToken.sol
@@ -7,6 +7,8 @@ import "../proposals/voting/StandardVote.sol";
 import "../proposals/voting/StakeVote.sol";
 import "../proposals/voting/Vote.sol";
 
+
+
 /// ::TODO::
 /// 1. Hadcoded functions (updateQuorum, updateMetric)
 /// need to be generalize to an updateStructure function

--- a/package-lock.json
+++ b/package-lock.json
@@ -3944,6 +3944,14 @@
         "is-promise": "2.1.0"
       }
     },
+    "runethtx": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/runethtx/-/runethtx-0.0.7.tgz",
+      "integrity": "sha1-kUXXp4Po44O/CVgN7ahzYx5vwpM=",
+      "requires": {
+        "async": "2.5.0"
+      }
+    },
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
@@ -4263,14 +4271,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4289,6 +4289,14 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.7.0",
         "function-bind": "1.1.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -4644,6 +4652,16 @@
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
+      }
+    },
+    "vaultcontract": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/vaultcontract/-/vaultcontract-0.2.20.tgz",
+      "integrity": "sha512-lGi3hS8TGU3ELsFDJtMZSb1K4fk/SHCC06ubmFr5aR6ZtTTODIqKEMSICiCvEZ74lWybJ3TIEOBGH55dx7/HpA==",
+      "requires": {
+        "async": "2.5.0",
+        "lodash": "4.17.4",
+        "runethtx": "0.0.7"
       }
     },
     "verror": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/VegaProject/vega-contracts#readme",
   "dependencies": {
     "minimetoken": "^0.1.7",
+    "vaultcontract": "^0.2.20",
     "truffle": "^3.4.11",
     "zeppelin-solidity": "^1.3.0"
   },

--- a/test/AllocationTest.js
+++ b/test/AllocationTest.js
@@ -7,9 +7,9 @@ let VegaToken = artifacts.require("VegaToken");
 let VegaCampaign = artifacts.require("VegaCampaign");
 let MiniMeTokenFactory = artifacts.require("MiniMeTokenFactory");
 let MiniMeToken = artifacts.require("MiniMeToken");
-let StandardVote = artifacts.require("StandardVote");
-let Allocation = artifacts.require("Allocation");
-
+let StandardVote = artifacts.require("StandardVote")
+let Allocation = artifacts.require("Allocation")
+let Vault = artifacts.require("Vault")
 
 const verbose = false;
 
@@ -36,7 +36,42 @@ contract("Allocation", (accounts) => {
         token
     ]
 
+    let vaultDeployParams = 
+    (caller, destination, minLockTime, timeLock, guard, guardDelay) => 
+    [
+        caller,
+        destination,
+        minLockTime,
+        timeLock,
+        guard,
+        guardDelay
+    ]
+
     before(async() => {
+
+        vault = await Vault.new.apply(
+            this,
+            vaultDeployParams(
+                accounts[0],
+                accounts[1],
+                0,
+                0,
+                accounts[1],
+                0
+                )
+        )
+
+        vault2 = await Vault.new.apply(
+            this,
+            vaultDeployParams(
+                accounts[0],
+                accounts[1],
+                0,
+                0,
+                accounts[1],
+                0
+                )
+        )
         factory = await MiniMeTokenFactory.new.apply(
             this  
         )
@@ -44,11 +79,24 @@ contract("Allocation", (accounts) => {
             this,
             [factory.address]
         )
+
+        vega2 = await VegaToken.new.apply(
+            this,
+            [factory.address]
+        )
+
         vegaCampaign = await VegaCampaign.new.apply(
             this,
-            campaignDeployParams(accounts[0], vega.address)
+            campaignDeployParams(vault.address, vega.address)
         )
+
+        vegaCampaign2 = await VegaCampaign.new.apply(
+            this,
+            campaignDeployParams(vault2.address, vega2.address)
+        )
+
         vega.changeController(vegaCampaign.address)
+        vega2.changeController(vegaCampaign2.address)    
 
         vote = await StandardVote.new.apply(
             this,
@@ -59,7 +107,7 @@ contract("Allocation", (accounts) => {
         allocation = await Allocation.new(
             TIME_INCREMENT,
             accounts[4],
-            vega.address,
+            vega2.address,
             TRANSFER_ONE,
             vote.address
         )
@@ -72,6 +120,15 @@ contract("Allocation", (accounts) => {
         valueOne = await vega.balanceOfAt(senderOne, web3.eth.getBlock(web3.eth.blockNumber).timestamp)
         valueOne.toNumber().should.be.equal(TRANSFER_ONE)
     })
+
+    it("should let sender one donate to the vega campaign2", async () => {
+       
+        // Use balanceOfAt as current MiniMeToken does not support balance()        
+        await vegaCampaign2.sendTransaction({from: senderOne, value: (TRANSFER_ONE)})
+        valueOne = await vega2.balanceOfAt(senderOne, web3.eth.getBlock(web3.eth.blockNumber).timestamp)
+        valueOne.toNumber().should.be.equal(TRANSFER_ONE)
+    })
+
     it("should let sender two donate to the vega campaign", async () => {    
         // Transfer tokens to second account
         await vegaCampaign.sendTransaction({from: senderTwo, value: TRANSFER_TWO})
@@ -82,7 +139,7 @@ contract("Allocation", (accounts) => {
         await vote.vote(true, {from: senderOne})
         await vote.countVote()
 
-        await vega.transfer(vega.address, TRANSFER_ONE, {from: senderOne} )
+        await vega2.transfer(vega.address, TRANSFER_ONE, {from: senderOne} )
 
         senderOneVoteIndex = await vote.statusMap(senderOne)
         senderOneVoteInfo = await vote.votes(senderOneVoteIndex[1].toNumber())
@@ -94,8 +151,7 @@ contract("Allocation", (accounts) => {
     })
     it("proposal should execute", async () => {    
         await vega.executeFinancialProposal(allocation.address)        
-        allocationValue = await vega.balanceOfAt(accounts[4], web3.eth.getBlock(web3.eth.blockNumber).timestamp)
-        
+        allocationValue = await vega2.balanceOfAt(accounts[4], web3.eth.getBlock(web3.eth.blockNumber).timestamp)
         allocationValue.toNumber().should.be.equal(TRANSFER_ONE)
     })
 });


### PR DESCRIPTION
Added a vault and additional token so that VGA doesn't have to hold it's own tokens. Tests are now carried out using two separate tokens. Currently, Ether is held in the vault while tokens are held in the VegaToken contract. Ideally, a solution that handles ether and tokens fluidly should be implemented possibly by using ERC23 standard. Alternatively, separate Financial proposals will be needed for Ether and standard ERC20 tokens.